### PR TITLE
Add support for mutations in schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,14 @@ const queryType = objectType('Query')
     .resolve((root, {id}) => starWarsData.Droids[id])
   .end();
 
-const starWarsSchema = schemaFrom(queryType);
+const mutationType = objectType('Mutation')
+  .field('updateCharacterName', characterInterface)
+    .arg('id', notNull(GraphQLString))
+    .arg('newName', notNull(GraphQLString))
+    .resolve((root, {id, newName}) => updateCharacterName(id, newName))
+  .end();
+
+const starWarsSchema = schemaFrom(queryType, mutationType);
 ```
 
 # Cyclic Types
@@ -149,9 +156,9 @@ Define a new `GraphQLObjectType`.
 ##### .arg(name, type, defaultValue, description)
 ##### .resolve(fn)
 
-## schemaFrom(type)
+## schemaFrom(queryRootType, mutationRootType)
 
-Define a new `GraphQLSchema` from the given type.
+Define a new `GraphQLSchema` from the given root types.
 
 ## listOf(type)
 

--- a/src/types.js
+++ b/src/types.js
@@ -12,8 +12,9 @@ export function notNull(type) {
   return new GraphQLNonNull(type);
 }
 
-export function schemaFrom(type) {
+export function schemaFrom(queryRootType, mutationRootType) {
   return new GraphQLSchema({
-    query: type
+    query: queryRootType,
+    mutation: mutationRootType
   });
 }


### PR DESCRIPTION
GraphQL also support mutations by defining `mutation` on schema root next to `query` type definition. It seems to be last missing piece here.
